### PR TITLE
Fixed typo - s/funding/finding/

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -6,7 +6,7 @@ description: "A security static analysis tool for Ruby on Rails applications"
 ---
 
 Welcome to Railroader!
-Railroader is a security static analysis tool for funding vulnerabilities
+Railroader is a security static analysis tool for finding vulnerabilities
 in applications that use Ruby on Rails.
 It's easy to [install](/install) and [use](/use).
 It is open source software (OSS) using the MIT license; we


### PR DESCRIPTION
Fixed typo - s/funding/finding/ - on main web page.